### PR TITLE
Add "exports" dependency to AMD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ will compile into this AMD output:
 
 ```javascript
 define("ember",
-  [],
+  ["exports"],
   function(__exports__) {
     var get = function(obj, key) {
       return obj[key];


### PR DESCRIPTION
The "Individual Exports" AMD example was missing the "exports" 
pseudo-dependency (aka "special dependency in RequireJS language).
I added it.
