### PR TITLE
Name based on relative paths in AMD transpiling

### DIFF
--- a/lib/amd_compiler.js
+++ b/lib/amd_compiler.js
@@ -1,11 +1,13 @@
 (function() {
   "use strict";
 
-  var AMDCompiler, AbstractCompiler, isEmpty,
+  var AMDCompiler, AbstractCompiler, isEmpty, path,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
 
   AbstractCompiler = require("./abstract_compiler");
+
+  path = require("path");
 
   isEmpty = require("./utils").isEmpty;
 
@@ -20,11 +22,17 @@
     AMDCompiler.prototype.stringify = function() {
       var _this = this;
       return this.build(function(s) {
-        var preamble, wrapperArgs, _ref;
+        var dependency, i, preamble, wrapperArgs, _ref;
         _ref = _this.buildPreamble(_this.dependencyNames), wrapperArgs = _ref[0], preamble = _ref[1];
         if (!isEmpty(_this.exports)) {
           _this.dependencyNames.push('exports');
           wrapperArgs.push('__exports__');
+        }
+        for (i in _this.dependencyNames) {
+          dependency = _this.dependencyNames[i];
+          if (/^\./.test(dependency)) {
+            _this.dependencyNames[i] = path.join(_this.moduleName, '..', dependency);
+          }
         }
         return s.line(function() {
           return s.call('define', function(arg) {

--- a/spec/amd_compiler_spec.coffee
+++ b/spec/amd_compiler_spec.coffee
@@ -113,3 +113,51 @@ describe 'Compiler (toAMD)', ->
           import { buzz } from "buzz"; */
         });
     """
+
+  it 'names modules and modifies import statements if a relative path is defined', ->
+    shouldRunCLI ['--to', 'out', 'lib'],
+      'lib':
+        contents: ['foo', 'foo.js']
+      'lib/foo':
+        contents: ['bar.js', 'baz.js']
+      'lib/foo.js':
+        read: """
+          import "./foo/bar" as bar;
+        """
+      'lib/foo/bar.js':
+        read: """
+          import "./baz" as baz;
+        """
+      'lib/foo/baz.js':
+        read: ""
+      'out':
+        exists: yes
+      'out/lib':
+        exists: yes
+      'out/lib/foo':
+        exists: yes
+      'out/lib/foo.js':
+        write: """
+          define("lib/foo",
+            ["lib/foo/bar"],
+            function(bar) {
+              "use strict";
+            });
+        """
+      'out/lib/foo/bar.js':
+        write: """
+          define("lib/foo/bar",
+            ["lib/foo/baz"],
+            function(baz) {
+              "use strict";
+            });
+        """
+      'out/lib/foo/baz.js':
+        write: """
+          define("lib/foo/baz",
+            [],
+            function() {
+              "use strict";
+
+            });
+        """

--- a/src/amd_compiler.coffee
+++ b/src/amd_compiler.coffee
@@ -1,5 +1,6 @@
 import './abstract_compiler' as AbstractCompiler
 import { isEmpty } from './utils'
+import 'path' as path;
 
 class AMDCompiler extends AbstractCompiler
   stringify: ->
@@ -9,6 +10,13 @@ class AMDCompiler extends AbstractCompiler
       unless isEmpty(@exports)
         @dependencyNames.push 'exports'
         wrapperArgs.push '__exports__'
+
+      for i of @dependencyNames
+        dependency = @dependencyNames[i]
+        if /^\./.test(dependency)
+          # '..' makes up for path.join() treating a module name w/ no extension
+          # as a folder
+          @dependencyNames[i] = path.join(@moduleName, '..', dependency)
 
       s.line =>
         s.call 'define', (arg) =>


### PR DESCRIPTION
See [this Gist](https://gist.github.com/thomasboyt/5703635) for rationale. tl;dr is that 

``` js
import { something } from "./foo/bar";
```

in a file called "lib/foo.js" will now AMD transpile to

``` js
define("lib/foo",
  ["lib/foo/bar", exports],
  function(__dependency1__, __exports__) {
    "use strict";
    var something = __dependency1__.something;
  });
```

allowing for relative pathing in your source being properly renamed when compiled to AMD.
