### PR TITLE
feat(windows compatibility): correct paths where necessary

### DIFF
--- a/lib/amd_compiler.js
+++ b/lib/amd_compiler.js
@@ -31,7 +31,7 @@
         for (i in _this.dependencyNames) {
           dependency = _this.dependencyNames[i];
           if (/^\./.test(dependency)) {
-            _this.dependencyNames[i] = path.join(_this.moduleName, '..', dependency);
+            _this.dependencyNames[i] = path.join(_this.moduleName, '..', dependency).replace(/[\\]/g, '/');
           }
         }
         return s.line(function() {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -187,12 +187,12 @@
       return this.fs.readFile(filename, 'utf8', function(err, input) {
         var ext, moduleName, output, outputFilename;
         ext = path.extname(filename);
-        moduleName = path.join(path.dirname(filename), path.basename(filename, ext));
+        moduleName = path.join(path.dirname(filename), path.basename(filename, ext)).replace(/[\\]/g, '/');
         output = _this._compile(input, moduleName, options.type, {
           coffee: ext === '.coffee',
           imports: options.imports
         });
-        outputFilename = path.join(options.to, filename);
+        outputFilename = path.join(options.to, filename).replace(/[\\]/g, '/');
         _this._mkdirp(path.dirname(outputFilename));
         return _this.fs.writeFile(outputFilename, output, 'utf8', function(err) {
           if (err) {

--- a/src/amd_compiler.coffee
+++ b/src/amd_compiler.coffee
@@ -16,7 +16,7 @@ class AMDCompiler extends AbstractCompiler
         if /^\./.test(dependency)
           # '..' makes up for path.join() treating a module name w/ no extension
           # as a folder
-          @dependencyNames[i] = path.join(@moduleName, '..', dependency)
+          @dependencyNames[i] = path.join(@moduleName, '..', dependency).replace(/[\\]/g, '/')
 
       s.line =>
         s.call 'define', (arg) =>

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -118,9 +118,9 @@ class CLI
   processFile: (filename, options) ->
     @fs.readFile filename, 'utf8', (err, input) =>
       ext = path.extname(filename)
-      moduleName = path.join(path.dirname(filename), path.basename(filename, ext))
+      moduleName = path.join(path.dirname(filename), path.basename(filename, ext)).replace(/[\\]/g, '/')
       output = @_compile input, moduleName, options.type, coffee: ext is '.coffee', imports: options.imports
-      outputFilename = path.join(options.to, filename)
+      outputFilename = path.join(options.to, filename).replace(/[\\]/g, '/')
 
       @_mkdirp path.dirname(outputFilename)
       @fs.writeFile outputFilename, output, 'utf8', (err) ->


### PR DESCRIPTION
A few changes:
- where cli and amd_compiler use functions of path to create filenames for
  inclusion in AMD define/require calls, replace backslashes with
  forward slashes as is necessary for require/define syntax
- FakeFileSystem internally represents paths given to the constructor in
  native format (this means backslashes in windows).
- FakeFileSystem normalizes parameters that represent paths so that they
  conform to the native path format for the platform.
