### PR TITLE
throw error, don't log it

### DIFF
--- a/lib/compile-modules.js
+++ b/lib/compile-modules.js
@@ -124,8 +124,7 @@ class CLI {
   processPath(filename, options) {
     this.fs.stat(filename, function(err, stat) {
       if (err) {
-        console.error(err.message);
-        process.exit(1);
+        throw new Error(err);
       } else if (stat.isDirectory()) {
         this.processDirectory(filename, options);
       } else {


### PR DESCRIPTION
makes debugging 10000000x better.
