### PR TITLE
Switch --anonymous flag for --infer-name. Fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Here is the basic usage:
 
 ```
 compile-modules FILE [FILE…] --to OUTPUT [--type=TYPE]
-  [--anonymous] [--module-name=NAME]
+  [--infer-name] [--module-name=NAME]
   [--global=GLOBAL] [--imports=IMPORTS]
 
 FILE
@@ -46,9 +46,10 @@ TYPE
   One of `amd` (for AMD output), `cjs` (for CommonJS output), `yui` (for YUI
   output).
 
-ANONYMOUS
-  If you use the --anonymous flag with the AMD type, the transpiler will output
-  a module with no name.
+INFER-NAME
+  If you use the --infer-name flag with the AMD or YUI type, the transpiler will
+  generate a name for the module from its file path. The default is to output
+  anonymous modules.
 
 NAME
   You can supply a name to use as the module name.  By default, the transpiler

--- a/lib/compile-modules.js
+++ b/lib/compile-modules.js
@@ -58,7 +58,7 @@ class CLI {
   }
 
   argParser(argv) {
-    return optimist(argv).usage('compile-modules usage:\n\n  Using files:\n    compile-modules INPUT --to DIR [--anonymous] [--type TYPE] [--imports PATH:GLOBAL]\n\n  Using stdio:\n    compile-modules --stdio [--type TYPE] [--imports PATH:GLOBAL] (--module-name MOD|--anonymous)').options({
+    return optimist(argv).usage('compile-modules usage:\n\n  Using files:\n    compile-modules INPUT --to DIR [--infer-name] [--type TYPE] [--imports PATH:GLOBAL]\n\n  Using stdio:\n    compile-modules --stdio [--type TYPE] [--imports PATH:GLOBAL] [--module-name MOD]').options({
       type: {
         "default": 'amd',
         describe: 'The type of output (one of "amd", "yui", "cjs", or "globals")'
@@ -69,10 +69,10 @@ class CLI {
       imports: {
         describe: 'A list of path:global pairs, comma separated (e.g. jquery:$,ember:Ember)'
       },
-      anonymous: {
+      'infer-name': {
         "default": false,
         type: 'boolean',
-        describe: 'Do not include a module name'
+        describe: 'Automatically generate names for AMD and YUI modules'
       },
       'module-name': {
         describe: 'The name of the outputted module',
@@ -94,9 +94,9 @@ class CLI {
         describe: 'Shows this help message'
       }
     }).check(({type}) => type === 'amd' || type === 'yui' || type === 'cjs' || type === 'globals')
-    .check(args => !args.anonymous || !args.m)
-    .check(args => (args.stdio && args.type === 'amd') ? args.anonymous || args.m || false : true)
-    .check(args => (args.stdio && args.type === 'yui') ? args.anonymous || args.m || false : true)
+    .check(args => !args['infer-name'] || !args.m)
+    .check(args => (args.stdio && args.type === 'amd') ? !args['infer-name'] : true)
+    .check(args => (args.stdio && args.type === 'yui') ? !args['infer-name'] : true)
     .check(args => args.stdio || args.to || args.help)
     .check(args => args.imports ? args.type === 'globals' : args.type !== 'globals');
   }
@@ -157,7 +157,7 @@ class CLI {
         pathNoExt      = normalizePath(path.join(dirname, basenameNoExt)),
         output,
         outputFilename = normalizePath(path.join(options.to, filename)),
-        moduleName     = options.anonymous ? null : pathNoExt;
+        moduleName     = options['infer-name'] ? pathNoExt : null;
 
     options = extend({}, options, {m: moduleName});
     this._mkdirp(path.dirname(outputFilename));


### PR DESCRIPTION
This PR makes anonymous modules the default for AMD output as discussed in #5.
