### PR TITLE
Upgrade Esprima

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "es6ify": "~0.2.0",
-    "esprima": "git://github.com/ariya/esprima.git#4bf313134c93e71a97524dada947c5d07b08702b",
+    "esprima": "git://github.com/ariya/esprima.git#89b3db92d57a65dd30505920831e7304f3768d4b",
     "grunt": "~0.4.1",
     "grunt-browserify": "~1.2.0",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
The primary motivation for this upgrade is to fix an issue on some runtimes
where an unquoted 'static' is considered a reserved word. There are also a
handful of other small changes.
