### PR TITLE
Newline handling is wonky

### DIFF
--- a/test/features/semicolons_optional.amd.js
+++ b/test/features/semicolons_optional.amd.js
@@ -1,7 +1,8 @@
 define(
-  ["jquery","rsvp","exports"],
-  function(__dependency1__, __dependency2__, __exports__) {
+  ["handlebars","jquery","rsvp","exports"],
+  function(__dependency1__, __dependency2__, __dependency3__, __exports__) {
     "use strict";
-    var ajax = __dependency1__.ajax;
-    __exports__.defer = __dependency2__.defer;
+    var x = {}
+    var ajax = __dependency2__.ajax;
+    __exports__.defer = __dependency3__.defer;
   });

--- a/test/features/semicolons_optional.cjs.js
+++ b/test/features/semicolons_optional.cjs.js
@@ -1,3 +1,5 @@
 "use strict";
+var x = {}
+require("handlebars")
 var ajax = require("jquery").ajax;
 exports.defer = require("rsvp").defer;

--- a/test/features/semicolons_optional.es6.js
+++ b/test/features/semicolons_optional.es6.js
@@ -1,2 +1,4 @@
+var x = {}
+import 'handlebars'
 import { ajax } from 'jquery'
 export { defer } from 'rsvp'

--- a/test/features/semicolons_optional.yui.js
+++ b/test/features/semicolons_optional.yui.js
@@ -1,6 +1,7 @@
 YUI.add("@NAME@", function(Y, NAME, __imports__, __exports__) {
     "use strict";
+    var x = {}
     var ajax = __imports__["jquery"].ajax;
     __exports__.defer = __imports__["rsvp"].defer;
     return __exports__;
-}, "@VERSION@", {"es":true,"requires":["jquery","rsvp"]});
+}, "@VERSION@", {"es":true,"requires":["handlebars","jquery","rsvp"]});


### PR DESCRIPTION
I'm attaching two failing tests. Both are edits to the same file (`test/features/semicolons_optional.es6.js`). The first is mostly cosmetic, for matching newlines in source and output (though I suspect something funny is going on in the logic that makes newlines disappear). The second one is an actual bug, because it produces invalid JavaScript like this:

``` js
var x = {}var ajax = __imports__["jquery"].ajax;
```

Mocha's output is not really pastable, but here's a screenshot showing the missing newlines in various places:

![screenshot](https://f.cloud.github.com/assets/524783/1655082/6a85556a-5b5b-11e3-8577-72ad0601f8d4.png)
