### PR TITLE
don't use the export global for imports

### DIFF
--- a/lib/globals_compiler.js
+++ b/lib/globals_compiler.js
@@ -66,7 +66,7 @@ class GlobalsCompiler extends AbstractCompiler {
 
     for (var idx = 0; idx < dependencyNames.length; idx++) {
       var name = dependencyNames[idx];
-      out += `${this.options.global}.${this.options.imports[name] || name}`;
+      out += `${this.options.imports[name] || name}`;
       if (!(idx === dependencyNames.length - 1)) out += ", ";
     }
 

--- a/test/features/block_comments.globals.js
+++ b/test/features/block_comments.globals.js
@@ -5,4 +5,4 @@
   import { bazz } from "bazz";
   import { bar } from "bar";
   import { buzz } from "buzz"; */
-})(window.RSVP);
+})(RSVP);

--- a/test/features/export_from_module.globals.js
+++ b/test/features/export_from_module.globals.js
@@ -2,4 +2,4 @@
   "use strict";
   __exports__.join = __dependency1__.join;
   __exports__.extname = __dependency1__.extname;
-})(window, window.path);
+})(window, path);

--- a/test/features/import_default.globals.js
+++ b/test/features/import_default.globals.js
@@ -1,4 +1,4 @@
 (function(__dependency1__) {
   "use strict";
   var RSVP = __dependency1__;
-})(window.RSVP);
+})(RSVP);

--- a/test/features/import_specifier_set.globals.js
+++ b/test/features/import_specifier_set.globals.js
@@ -3,4 +3,4 @@
   var get = __dependency1__.get;
   var set = __dependency1__.set;
   var makeDeferred = __dependency2__.defer;
-})(window.Ember, window.RSVP);
+})(Ember, RSVP);

--- a/test/features/multiple_import_from_same_path.globals.js
+++ b/test/features/multiple_import_from_same_path.globals.js
@@ -2,4 +2,4 @@
   "use strict";
   var uniq = __dependency1__.uniq;
   var forEach = __dependency1__.forEach;
-})(window.utils);
+})(utils);


### PR DESCRIPTION
Previously if exporting to `foo`, all imports would be expected to be on `foo`, even with the `imports` options specified, making it impossible to import pretty much anything when using the `global` option.

I considered using `window` on all imports, but if something is truly global you shouldn't need that. Additionally, in some environments you wouldn't have `window`. I realize it is unlikely to be used anywhere but a browser, but this still works in browsers and consumers can configure an `import` to add `window` or `this` if needed.
