### PR TITLE
Clarify that "globals" can be a type option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ OUTPUT
 
 TYPE
   One of `amd` (for AMD output), `cjs` (for CommonJS output), `yui` (for YUI
-  output).
+  output), `globals` (for global variable output).
 
 INFER-NAME
   If you use the --infer-name flag with the AMD or YUI type, the transpiler will


### PR DESCRIPTION
This is already mentioned in the descriptions of the other command line arguments, but this addition makes it a little more clear.

Thanks! :sparkles: 
