### PR TITLE
Added ability to disable "use strict".

### DIFF
--- a/lib/abstract_compiler.js
+++ b/lib/abstract_compiler.js
@@ -15,6 +15,9 @@ class AbstractCompiler {
     this.string = compiler.string;
 
     this.options = options;
+    if (typeof options.useStrict === 'undefined') {
+      this.options.useStrict = true;
+    }
 
     var allDependencies = this.imports.concat(this.exports.filter(function(export_) {
       return export_.source !== null;

--- a/lib/amd_compiler.js
+++ b/lib/amd_compiler.js
@@ -51,7 +51,9 @@ class AMDCompiler extends AbstractCompiler {
 
     out += ") {\n";
 
-    out += '    "use strict";\n';
+    if (this.options.useStrict) {
+      out += '    "use strict";\n';
+    }
 
     return out;
   }

--- a/lib/cjs_compiler.js
+++ b/lib/cjs_compiler.js
@@ -40,7 +40,10 @@ class CJSCompiler extends AbstractCompiler {
     this.buildImports();
     this.buildExports();
 
-    var out = `"use strict";\n`;
+    var out = '';
+    if (this.options.useStrict) {
+      out += `"use strict";\n`;
+    }
     for (var source of this.prelude) {
       out += source + "\n";
     }

--- a/lib/compile-modules.js
+++ b/lib/compile-modules.js
@@ -87,6 +87,11 @@ class CLI {
       global: {
         describe: 'When the type is `globals`, the name of the global to export into'
       },
+      'not-strict': {
+        "default": true,
+        type: 'boolean',
+        describe: 'Don\'t add \'use strict\' to the outputted module'
+      },
       help: {
         "default": false,
         type: 'boolean',

--- a/lib/globals_compiler.js
+++ b/lib/globals_compiler.js
@@ -44,7 +44,9 @@ class GlobalsCompiler extends AbstractCompiler {
 
     out += ") {\n";
 
-    out += '  "use strict";\n';
+    if (this.options.useStrict) {
+      out += '  "use strict";\n';
+    }
 
     return out;
   }


### PR DESCRIPTION
I'd still like to be able to use this transpiler with a legacy codebase which has some files that aren't strict. I know that the legacy modules won't work in ES6 <module> tags but I'm okay with that.
