### PR TITLE
[fixes #136] adding support for `processExportReassignment`

### DIFF
--- a/lib/formatters/bundle_formatter.js
+++ b/lib/formatters/bundle_formatter.js
@@ -172,6 +172,21 @@ BundleFormatter.prototype.processImportDeclaration = function(mod, nodePath) {
 };
 
 /**
+ * Since named export reassignment is just a local variable, we can ignore it.
+ * e.g.
+ *
+ * export var foo = 1;
+ * foo = 2;
+ *
+ * @param {Module} mod
+ * @param {ast-types.NodePath} nodePath
+ * @return {?Replacement}
+ */
+BundleFormatter.prototype.processExportReassignment = function (mod, nodePath) {
+  return null;
+};
+
+/**
  * Get a reference to the original exported value referenced in `mod` at
  * `referencePath`. If the given reference path does not correspond to an
  * export, we do not need to rewrite the reference. For example, since `value`

--- a/lib/formatters/commonjs_formatter.js
+++ b/lib/formatters/commonjs_formatter.js
@@ -189,6 +189,21 @@ CommonJSFormatter.prototype.processImportDeclaration = function(mod, nodePath) {
 };
 
 /**
+ * Since named export reassignment is just a local variable, we can ignore it.
+ * e.g.
+ *
+ * export var foo = 1;
+ * foo = 2;
+ *
+ * @param {Module} mod
+ * @param {ast-types.NodePath} nodePath
+ * @return {?Replacement}
+ */
+CommonJSFormatter.prototype.processExportReassignment = function (mod, nodePath) {
+  return null;
+};
+
+/**
  * Convert a list of ordered modules into a list of files.
  *
  * @param {Array.<Module>} modules Modules in execution order.

--- a/lib/rewriter.js
+++ b/lib/rewriter.js
@@ -111,6 +111,9 @@ Rewriter.prototype.processNodePath = function(mod, nodePath) {
      * Static Semantics: Early Errors).
      */
     this.assertImportIsNotReassigned(mod, nodePath.get('left'));
+    if (mod.exports.findDeclarationForReference(nodePath.get('left'))) {
+      return formatter.processExportReassignment(mod, nodePath);
+    }
   } else if (n.VariableDeclaration.check(node) && nodePath.scope.isGlobal) {
     return formatter.processVariableDeclaration(mod, nodePath);
   } else if (n.FunctionDeclaration.check(node) && n.Program.check(nodePath.parent.node)) {
@@ -147,6 +150,9 @@ Rewriter.prototype.processNodePath = function(mod, nodePath) {
     return formatter.processImportDeclaration(mod, nodePath);
   } else if (n.UpdateExpression.check(node)) {
     this.assertImportIsNotReassigned(mod, nodePath.get('argument'));
+    if (mod.exports.findDeclarationForReference(nodePath.get('argument'))) {
+      return formatter.processExportReassignment(mod, nodePath);
+    }
   } else {
     return null;
   }


### PR DESCRIPTION
This covers these cases:

``` javascript
export var a = 4;
export var b = 5 + 1;
export var c = typeof a;
export var d = a++;
export var e = ++a;

a -= 10;

--a;

export function reassign() {
  a = 10;
}

for (var i = 0; a = i, i < 10; i++) {
    console.log(i);
}
```

allowing us to control the updates on named exports for `System.register()` formatter.
