### PR TITLE
Add `src` property to Module for control over I/O

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -43,6 +43,7 @@ function Module(path, relativePath, container) {
  * Clears the cached data for this module.
  */
 Module.prototype.reload = function() {
+  delete this.src;
   delete this.ast;
   delete this.imports;
   delete this.exports;
@@ -91,11 +92,21 @@ memo(Module.prototype, 'scope', function() {
  */
 memo(Module.prototype, 'ast', function() {
   return recast.parse(
-    fs.readFileSync(this.path).toString(), {
+    this.src, {
       esprima: esprima,
       sourceFileName: Path.basename(this.path)
     }
   );
+});
+
+/**
+ * This module's source code.
+ *
+ * @type {String}
+ * @property src
+ */
+memo(Module.prototype, 'src', function() {
+  return fs.readFileSync(this.path).toString();
 });
 
 /**


### PR DESCRIPTION
This splits apart reading in the module src code from parsing it into an AST. By adding a `src` property to Module instances, there's now a hook to control file I/O — for instance to cache the src of unchanged modules between re-builds.
