### PR TITLE
Add Module to exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,9 @@
 var Container = require('./container');
 var FileResolver = require('./file_resolver');
 var formatters = require('./formatters');
+var Module = require('./module');
 
 exports.FileResolver = FileResolver;
 exports.Container = Container;
 exports.formatters = formatters;
+exports.Module = Module;


### PR DESCRIPTION
I working on a `gulp` plugin for the current version of `es6-module-transpiler`.

Since `gulp` usually already reads the files, I am creating `Module` objects manually and adding them using `container.addModule` directly. However, the `Module` constructor is currently not exposed.

This PR simply exposes the `Module` for build tool development to not have to do: `require('es6-module-transpiler/lib/module')`

Please let me know, if you have something agains exposing the `Module` constructor.

Thanks for the great tool!
