### PR TITLE
Allow writing a container multiple times.

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -97,6 +97,13 @@ Container.prototype.addModule = function(mod) {
     return;
   }
 
+  if (this._convertResult) {
+    throw new Error(
+      'container has already converted contained modules ' +
+      'and cannot add new module: ' + mod.path
+    );
+  }
+
   // We have not seen this module before, so let's give it a unique name.
   var modules = this.getModules();
   var name = mod.name;
@@ -138,7 +145,10 @@ Container.prototype.getCachedModule = function(resolvedPath) {
  * @param {string} target
  */
 Container.prototype.write = function(target) {
-  var files = this.convert();
+  if (!this._convertResult) {
+    this._convertResult = this.convert();
+  }
+  var files = this._convertResult;
   var writer = new Writer(target);
   writer.write(files);
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "example-runner": "^0.1.0",
-    "mocha": "^1.20.1"
+    "mocha": "^1.20.1",
+    "tmp": "0.0.24"
   }
 }

--- a/test/support/test_formatter.js
+++ b/test/support/test_formatter.js
@@ -1,0 +1,61 @@
+var Formatter = require('../../lib/formatters/formatter');
+var extend = require('../../lib/utils').extend;
+
+/**
+ * This basic formatter does not alter the AST at all, and only exists
+ * help write unit tests for things that depend on formatters.
+ *
+ * @class
+ * @extends Formatter
+ */
+function TestFormatter() {
+  Formatter.call(this);
+}
+extend(TestFormatter, Formatter);
+
+/**
+ * @override
+ */
+TestFormatter.prototype.build = function(modules) {
+  return modules.map(function(mod) {
+    var ast = mod.ast;
+    ast.filename = mod.relativePath;
+    return ast;
+  });
+};
+/**
+ * @override
+ */
+TestFormatter.prototype.processExportDeclaration = function() {
+  return null;
+};
+
+/**
+ * @override
+ */
+TestFormatter.prototype.processExportReassignment = function() {
+  return null;
+};
+
+/**
+ * @override
+ */
+TestFormatter.prototype.processImportDeclaration = function() {
+  return null;
+};
+
+/**
+ * @override
+ */
+TestFormatter.prototype.processFunctionDeclaration = function() {
+  return null;
+};
+
+/**
+ * @override
+ */
+TestFormatter.prototype.processVariableDeclaration = function() {
+  return null;
+};
+
+exports.TestFormatter = TestFormatter;

--- a/test/support/test_resolver.js
+++ b/test/support/test_resolver.js
@@ -1,0 +1,31 @@
+var Module = require('../../lib/module');
+var Path = require('path');
+
+/**
+ * This basic resolver just returns a module whose #src is set to an
+ * empty string to prevent an attempt to read from the file system.
+ *
+ * @class
+ * @param {Object.<string,string>=} sources
+ */
+function TestResolver(sources) {
+  this.sources = sources || {};
+}
+
+/**
+ * @param {string} path
+ * @param {Module} mod
+ * @param {Container} container
+ * @returns {Module}
+ */
+TestResolver.prototype.resolveModule = function(path, mod, container) {
+  if (mod) {
+    path = Path.normalize(Path.join(mod.relativePath, '..', path));
+  }
+
+  var resolved = new Module(path, path, container);
+  resolved.src = this.sources[path] || '';
+  return resolved;
+};
+
+exports.TestResolver = TestResolver;

--- a/test/unit/container_test.js
+++ b/test/unit/container_test.js
@@ -1,0 +1,100 @@
+var Container = require('../../lib/container');
+var Module = require('../../lib/module');
+var Path = require('path');
+var TestFormatter = require('../support/test_formatter').TestFormatter;
+var TestResolver = require('../support/test_resolver').TestResolver;
+var assert = require('assert');
+var fs = require('fs');
+var tmp = require('tmp');
+
+describe('Container', function() {
+  describe('#write', function() {
+    it('allows multiple calls but only converts once', function(done) {
+      var buildCallCount = 0;
+      var source = 'var a = 1;';
+      var formatter = new TestFormatter();
+
+      /**
+       * This formatter only exists to count the number of times #build is
+       * called and create a result of the right data structure.
+       *
+       * @param {Module[]} modules
+       * @returns {File[]}
+       */
+      formatter.build = function(modules) {
+        buildCallCount++;
+        return TestFormatter.prototype.build.call(this, modules);
+      };
+
+      var container = new Container({
+        formatter: formatter,
+        resolvers: [new TestResolver({
+          'a.js': source
+        })]
+      });
+
+      // Ensure we have a module to write at all.
+      container.getModule('a.js');
+
+      tmp.dir(function(err, path) {
+        if (err) { return done(err); }
+
+        // Write the contents to a temporary directory.
+        container.write(path);
+        assert.strictEqual(buildCallCount, 1);
+
+        // Ensure that the written file contains the original code.
+        var a1 = fs.readFileSync(Path.join(path, 'a.js'), 'utf8');
+        assert.ok(
+          a1.indexOf(source) === 0,
+          'expected written source to start with original source, but was: ' + a1
+        );
+
+        tmp.dir(function(err, path2) {
+          if (err) { return done(err); }
+          assert.notStrictEqual(path, path2);
+
+          // Write to yet another temporary directory with the same container.
+          container.write(path2);
+          assert.strictEqual(buildCallCount, 1);
+
+          // Ensure that the written file contains the original code.
+          var a2 = fs.readFileSync(Path.join(path2, 'a.js'), 'utf8');
+          assert.ok(
+            a2.indexOf(source) === 0,
+            'expected written source to start with original source, but was: ' + a2
+          );
+
+          done();
+        });
+      });
+    });
+
+    it('freezes the container, effectively preventing adding new modules', function(done) {
+      var container = new Container({
+        formatter: new TestFormatter(),
+        resolvers: [new TestResolver()]
+      });
+
+      container.getModule('a.js');
+
+      tmp.dir(function(err, path) {
+        if (err) { return done(err); }
+
+        container.write(path);
+
+        try {
+          container.getModule('b.js');
+          assert.fail('expected an exception');
+        } catch (ex) {
+          assert.strictEqual(
+            'container has already converted contained modules and cannot add new module: b.js',
+            ex.message
+          );
+        }
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
@caridy @tbranyen 

What do you think of this approach to allowing multiple write calls? It's effectively making it more explicit that the contained modules are not re-usable once the conversion has happened. We still only format/build the result once, but we now cache the result and re-use it on subsequent calls to #write.

Closes #155.
