### PR TITLE
fix for commonjs formatter for esprima PR 287

### DIFF
--- a/lib/formatters/commonjs_formatter.js
+++ b/lib/formatters/commonjs_formatter.js
@@ -220,22 +220,29 @@ CommonJSFormatter.prototype.defaultExport = function(mod, declaration) {
     // export default function foo () {}
     // -> becomes:
     // function foo () {}
-    // var <moduleName>default = foo;
+    // export.default = foo;
     return [
       declaration,
-      b.variableDeclaration(
-        'var',
-        [b.variableDeclarator(
-          this.defaultExportReference(mod),
-          declaration.id
-        )]
-      )
+      b.expressionStatement(b.assignmentExpression(
+        '=',
+        b.memberExpression(
+          b.identifier('exports'),
+          b.literal('default'),
+          true
+        ),
+        declaration.id
+      ))
     ];
   }
-  return b.variableDeclaration(
-    'var',
-    [b.variableDeclarator(this.defaultExportReference(mod), declaration)]
-  );
+  return b.expressionStatement(b.assignmentExpression(
+    '=',
+    b.memberExpression(
+      b.identifier('exports'),
+      b.literal('default'),
+      true
+    ),
+    declaration
+  ));
 };
 
 /**

--- a/test/examples/export-default-function/exporter.js
+++ b/test/examples/export-default-function/exporter.js
@@ -1,0 +1,5 @@
+/* jshint esnext:true */
+
+export default function () {
+  return 1;
+}

--- a/test/examples/export-default-function/importer.js
+++ b/test/examples/export-default-function/importer.js
@@ -1,0 +1,8 @@
+/* jshint esnext:true */
+
+import fn1 from './exporter';
+
+import { default as fn2 } from './exporter';
+
+assert.equal(fn1(), 1);
+assert.equal(fn2(), 1);

--- a/test/examples/export-from-default/first.js
+++ b/test/examples/export-from-default/first.js
@@ -1,0 +1,3 @@
+/* jshint esnext:true */
+
+export default 1;

--- a/test/examples/export-from-default/second.js
+++ b/test/examples/export-from-default/second.js
@@ -1,0 +1,3 @@
+/* jshint esnext:true */
+
+export { default } from './first';

--- a/test/examples/export-from-default/third.js
+++ b/test/examples/export-from-default/third.js
@@ -1,0 +1,4 @@
+/* jshint esnext:true */
+
+import a from './second';
+assert.equal(a, 1);


### PR DESCRIPTION
plus more tests for:

```
export default function () {}
import { default as fn2 } from './exporter';
export { default } from './first';
```
