### PR TITLE
Improved compatibility of mkdirpSync

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,9 +80,9 @@ function mkdirpSync(path) {
   var parts = path.split('/');
   var dir = '';
 
-  parts.forEach(function(part) {
-    dir += '/' + part;
-    if (!fs.existsSync(dir)) {
+  parts.forEach(function(part,i) {
+    dir += (i>0?'/':'') + part;
+    if (dir && !fs.existsSync(dir)) {
       fs.mkdirSync(dir);
     }
   });


### PR DESCRIPTION
This fix addresses an issue with Mac OS X 10.9.5 and the new mkdirpSync util. It was prepending an extra slash to paths (i.e. //git/path/to/folder) which was causing write failures.
