### PR TITLE
Possibility to use file extensions other than .js

### DIFF
--- a/lib/file_resolver.js
+++ b/lib/file_resolver.js
@@ -67,9 +67,17 @@ FileResolver.prototype.resolvePath = function(importedPath, fromModule) {
   for (var i = 0, length = paths.length; i < length; i++) {
     var includePath = paths[i];
     var resolved = Path.resolve(includePath, importedPath);
-    if (resolved.slice(-3).toLowerCase() !== '.js') {
+    if (!~resolved.lastIndexOf('.')) {
       resolved += '.js';
     }
+    
+    if (fs.existsSync(resolved)) {
+      return resolved;
+    }
+
+    // edge cases when a module may have dotted filename, i.e. jquery.min.js
+    // and the module name is passed without the extension
+    resolved += '.js';
     if (fs.existsSync(resolved)) {
       return resolved;
     }


### PR DESCRIPTION
With this little trick one can use custom file extensions (i.e. `.es6`) without the need to translate them into `.js` every time. Some edge cases will be penalised by a double check on the filesystem, but hopefully those edge cases could be very rare.