### PR TITLE
Add support for exporting ES6 classes.

### DIFF
--- a/lib/exports.js
+++ b/lib/exports.js
@@ -51,6 +51,8 @@ ExportDeclarationList.prototype.declarationForNode = function(node) {
     return new VariableExportDeclaration(this.module, node);
   } else if (n.FunctionDeclaration.check(node.declaration)) {
     return new FunctionExportDeclaration(this.module, node);
+  } else if (n.ClassDeclaration.check(node.declaration)) {
+    return new ClassExportDeclaration(this.module, node);
   } else if (n.ExportBatchSpecifier.check(node.specifiers[0])) {
     throw new Error(
       '`export *` found at ' + sourcePosition(this.module, node) +
@@ -198,6 +200,31 @@ memo(VariableExportDeclaration.prototype, 'specifiers', /** @this VariableExport
   return this.node.declaration.declarations.map(function(declarator) {
     return new ExportSpecifier(self, declarator);
   });
+});
+
+/**
+ * Represents an export declaration of the form:
+ *
+ *   export class Foo {}
+ *
+ * @constructor
+ * @extends ExportDeclaration
+ * @param {Module} mod
+ * @param {AST.ExportDeclaration} node
+ */
+function ClassExportDeclaration(mod, node) {
+  ExportDeclaration.call(this, mod, node);
+}
+extend(ClassExportDeclaration, ExportDeclaration);
+
+/**
+ * Gets the list of export specifiers for this declaration.
+ *
+ * @type {ExportSpecifier[]}
+ * @name ClassExportDeclaration#specifiers
+ */
+memo(ClassExportDeclaration.prototype, 'specifiers', /** @this ClassExportDeclaration */function() {
+  return [new ExportSpecifier(this, this.node.declaration)];
 });
 
 /**

--- a/lib/formatters/bundle_formatter.js
+++ b/lib/formatters/bundle_formatter.js
@@ -329,6 +329,14 @@ BundleFormatter.prototype.processExportDeclaration = function(mod, nodePath) {
       // transform the function
       this.processFunctionDeclaration(mod, nodePath.get('declaration'))
     );
+  } else if (n.ClassDeclaration.check(node.declaration)) {
+    return Replacement.swaps(
+      // drop `export`
+      nodePath, node.declaration
+    ).and(
+      // transform the class
+      this.processClassDeclaration(mod, nodePath.get('declaration'))
+    );
   } else if (n.VariableDeclaration.check(node.declaration)) {
     return Replacement.swaps(
       // drop `export`
@@ -388,6 +396,28 @@ BundleFormatter.prototype.processExportReassignment = function(mod, nodePath) {
  * @override
  */
 BundleFormatter.prototype.processFunctionDeclaration = function(mod, nodePath) {
+  return Replacement.swaps(
+    nodePath.get('id'),
+    this.reference(mod, nodePath.node.id)
+  );
+};
+
+/**
+ * Rename the top-level class declaration to a unique name.
+ *
+ *   ```js
+ *   class Foo {}
+ *   ```
+ *
+ * Becomes e.g.
+ *
+ *   ```js
+ *   class mod$$Foo {}
+ *   ```
+ *
+ * @override
+ */
+BundleFormatter.prototype.processClassDeclaration = function(mod, nodePath) {
   return Replacement.swaps(
     nodePath.get('id'),
     this.reference(mod, nodePath.node.id)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "browserify": "^5.12.1",
+    "es6-class": "^0.9.1",
     "example-runner": "^0.1.0",
     "fake-fs": "^0.4.0",
     "mocha": "^1.20.1",

--- a/test/examples/export-class-expression/exporter.js
+++ b/test/examples/export-class-expression/exporter.js
@@ -1,0 +1,3 @@
+/* jshint esnext:true */
+
+export default class {};

--- a/test/examples/export-class-expression/importer.js
+++ b/test/examples/export-class-expression/importer.js
@@ -1,0 +1,5 @@
+/* jshint esnext:true */
+
+import Foo from './exporter';
+
+assert.strictEqual(new Foo().constructor, Foo);

--- a/test/examples/export-class/exporter.js
+++ b/test/examples/export-class/exporter.js
@@ -1,0 +1,3 @@
+/* jshint esnext:true */
+
+export class Foo {}

--- a/test/examples/export-class/importer.js
+++ b/test/examples/export-class/importer.js
@@ -1,0 +1,5 @@
+/* jshint esnext:true */
+
+import { Foo } from './exporter';
+
+assert.strictEqual(new Foo().constructor, Foo);

--- a/test/examples/export-default-class/exporter.js
+++ b/test/examples/export-default-class/exporter.js
@@ -1,0 +1,8 @@
+/* jshint esnext:true */
+
+export default class Point {
+  constructor(x, y) {
+    this.x = x;
+    this.y = y;
+  }
+}

--- a/test/examples/export-default-class/importer.js
+++ b/test/examples/export-default-class/importer.js
@@ -1,0 +1,6 @@
+/* jshint esnext:true */
+
+import Point from './exporter';
+
+assert.strictEqual(new Point(1, 2).x, 1);
+assert.strictEqual(new Point(1, 2).y, 2);

--- a/test/runner.js
+++ b/test/runner.js
@@ -6,6 +6,7 @@ var fs = require('fs');
 var Path = require('path');
 var vm = require('vm');
 var assert = require('assert');
+var es6class = require('es6-class');
 
 var modules = require('../lib');
 var utils = require('../lib/utils');
@@ -183,7 +184,7 @@ function requireTestFile(path, relativeTo, assert) {
   };
 
   // Hack to work around an issue where vm does not set `this` to the context.
-  code = '(function(){' + code + '\n}).call(global);';
+  code = '(function(){' + es6class.compile(code).code + '\n}).call(global);';
   vm.runInNewContext(code, testFileGlobal, path);
 
   testFileCache[path] = mod.exports;


### PR DESCRIPTION
@caridy @domenic

This should allow the module transpiler to work properly when classes are exported. I believe the three cases @caridy added are tested in this PR.

Closes #176.
