### PR TITLE
Improves sourcemap infrastructure

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -17,7 +17,9 @@ var Resolver;
  * @param {{resolvers: Resolver[], formatter: Formatter}} options
  */
 function Container(options) {
-  var formatter = options && options.formatter;
+  options = options || {};
+
+  var formatter = options.formatter;
   if (typeof formatter === 'function') {
     formatter = new formatter();
   }
@@ -27,7 +29,7 @@ function Container(options) {
     'missing required option `formatter`'
   );
 
-  var resolvers = options && options.resolvers;
+  var resolvers = options.resolvers;
 
   assert.ok(
     resolvers && resolvers.length > 0,
@@ -55,6 +57,14 @@ function Container(options) {
 
     options: {
       value: options
+    },
+
+    basePath: {
+      value: options.basePath || process.cwd()
+    },
+
+    sourceRoot: {
+      value: options.sourceRoot || '/'
     }
   });
 }
@@ -151,7 +161,10 @@ Container.prototype.write = function(target) {
     this._convertResult = this.convert();
   }
   var files = this._convertResult;
-  var writer = new Writer(target);
+  var writer = new Writer(target, {
+    sourceRoot: this.sourceRoot,
+    basePath: this.basePath
+  });
   writer.write(files);
 };
 
@@ -170,7 +183,8 @@ Container.prototype.transform = function() {
 
   files.forEach(function(file) {
     var rendered = recast.print(file, {
-      sourceMapName: Path.basename(file.filename)
+      sourceMapName: Path.relative(this.basePath, file.filename),
+      sourceRoot: this.sourceRoot
     });
     var code = rendered.code;
     var map = rendered.map;
@@ -180,7 +194,7 @@ Container.prototype.transform = function() {
       code: code,
       map: map
     });
-  });
+  }, this);
 
   return codes;
 };

--- a/lib/file_resolver.js
+++ b/lib/file_resolver.js
@@ -41,14 +41,7 @@ FileResolver.prototype.resolveModule = function(importedPath, fromModule, contai
       if (!Path.extname(importedPath)) {
         importedPath += Path.extname(resolvedPath);
       }
-      var includePath;
-      this.paths.some(function (path) {
-        if (resolvedPath.indexOf(path) === 0) {
-          includePath = path;
-          return true;
-        }
-      });
-      return new Module(resolvedPath, importedPath, container, includePath);
+      return new Module(resolvedPath, importedPath, container);
     }
   } else {
     return null;

--- a/lib/module.js
+++ b/lib/module.js
@@ -25,7 +25,7 @@ var endsWith = utils.endsWith;
  * @param {Container} container
  * @constructor
  */
-function Module(path, relativePath, container, includePath) {
+function Module(path, relativePath, container) {
   Object.defineProperties(this, {
     /**
      * @type {string}
@@ -52,9 +52,7 @@ function Module(path, relativePath, container, includePath) {
      * @name Module#sourceFileName
      */
     sourceFileName: {
-      value: includePath ?
-          Path.relative(includePath, path) :
-          Path.basename(path), // bc for resolvers without includePath
+      value: Path.relative(container.basePath, path),
       enumerable: true,
       writable: false
     },

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -6,8 +6,11 @@ var fs = require('fs');
 var Path = require('path');
 var mkdirpSync = require('./utils').mkdirpSync;
 
-function Writer(target) {
+function Writer(target, options) {
+  options = options || {};
   this.target = target;
+  this.basePath = options.basePath || process.cwd();
+  this.sourceRoot = options.sourceRoot;
 }
 
 Writer.prototype.write = function(files) {
@@ -50,7 +53,8 @@ Writer.prototype.writeFile = function(file, filename) {
   var sourceMapFilename = filename + '.map';
 
   var rendered = recast.print(file, {
-    sourceMapName: Path.basename(filename)
+    sourceMapName: Path.relative(this.basePath, filename),
+    sourceRoot: this.sourceRoot
   });
 
   var code = rendered.code;


### PR DESCRIPTION
- uses `paths` to resolve the relative path to the source in maps
- includes a new property for modules called `sourceFileName` that is meant to be used to generate the right folder structure when debugging using sourcemaps

As a result of this PR, now we can see the right structure when debugging, instead of the current flat list of files, e.g.:

![image](https://cloud.githubusercontent.com/assets/38969/5051146/d7f07180-6c02-11e4-9f3f-1d911a9fc715.png)
