### PR TITLE
Avoid risky JSON.stringify in utils.IIFE.

### DIFF
--- a/lib/formatters/bundle_formatter.js
+++ b/lib/formatters/bundle_formatter.js
@@ -7,7 +7,7 @@ var n = types.namedTypes;
 
 var Replacement = require('../replacement');
 var utils = require('../utils');
-var IFFE = utils.IFFE;
+var IIFE = utils.IIFE;
 var extend = utils.extend;
 var sort = require('../sorting').sort;
 var Formatter = require('./formatter');
@@ -76,7 +76,7 @@ BundleFormatter.prototype.beforeConvert = function(container) {
  */
 BundleFormatter.prototype.build = function(modules) {
   modules = sort(modules);
-  return [b.file(b.program([b.expressionStatement(IFFE(
+  return [b.file(b.program([b.expressionStatement(IIFE(
     b.expressionStatement(b.literal('use strict')),
       this.buildNamespaceImportObjects(modules),
       modules.length === 1 ?

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 /* jshint node:true, undef:true, unused:true */
 
 var recast = require('recast');
+var n = recast.types.namedTypes;
+var b = recast.types.builders;
 var esprima = require('esprima-fb');
 var realFS = require('fs');
 var Path = require('path');
@@ -53,29 +55,29 @@ function sourcePosition(mod, node) {
 }
 exports.sourcePosition = sourcePosition;
 
-function IFFE() {
-  if (!IFFE.AST) {
-    IFFE.AST = JSON.stringify(
-      recast.parse('(function(){}).call(this)', { esprima: esprima })
-    );
-  }
+function IIFE() {
+  var body = [];
+  var args = Array.prototype.concat.apply(body, arguments);
 
-  var result = JSON.parse(IFFE.AST);
-  var expression = result.program.body[0].expression;
-  var body = expression.callee.object.body.body;
-
-  var args = Array.prototype.slice.call(arguments);
-  args.forEach(function(arg) {
-    if (Object.prototype.toString.call(arg) === '[object Array]') {
-      body.push.apply(body, arg);
-    } else {
-      body.push(arg);
+  args.forEach(function(node) {
+    if (n.Expression.check(node)) {
+      node = b.expressionStatement(node);
+    }
+    if (n.Statement.check(node)) {
+      body.push(node);
     }
   });
 
-  return expression;
+  return b.callExpression(
+    b.memberExpression(
+      b.functionExpression(null, [], b.blockStatement(body)),
+      b.identifier("call"),
+      false
+    ),
+    [b.thisExpression()]
+  );
 }
-exports.IFFE = IFFE;
+exports.IIFE = IIFE;
 
 /**
  * Create a hierarchy of directories of it does not already exist.


### PR DESCRIPTION
This helps with issues like https://github.com/benjamn/recast/issues/135, because `Lines` objects are not (currently) `JSON.stringify`-serializable.

I also took the liberty of changing the name from `IFFE` to `IIFE`, since it creates an Immediately-Invoked Function Expression ;)

Unrelated: http://www.beatport.com/release/iffy/1386702
