### PR TITLE
[BUGFIX] exporting a named function assumed you always provided a semi-colon, which is unnecessary and so incorrectly consumed the next character

### DIFF
--- a/lib/abstract_compiler.js
+++ b/lib/abstract_compiler.js
@@ -92,7 +92,7 @@ class AbstractCompiler {
           source.replace(export_.range[0], export_.declaration.range[0] - 1, "");
 
           replacement = this.doExportDeclaration(name);
-          source.replace(export_.range[1] + 1, export_.range[1] + 1, replacement);
+          source.replace(export_.range[1] + 1, export_.range[1], replacement);
         } else if (export_.declaration.type === "Identifier") {
           var name = export_.declaration.name;
 

--- a/test/features/export_function_bug.amd.js
+++ b/test/features/export_function_bug.amd.js
@@ -1,0 +1,8 @@
+define(
+  ["exports"],
+  function(__exports__) {
+    "use strict";
+    function jQuery() { }
+
+    __exports__.jQuery = jQuery;// test
+  });

--- a/test/features/export_function_bug.es6.js
+++ b/test/features/export_function_bug.es6.js
@@ -1,0 +1,2 @@
+export function jQuery() { }
+// test

--- a/test/features/export_function_bug.globals.js
+++ b/test/features/export_function_bug.globals.js
@@ -1,0 +1,6 @@
+(function(__exports__) {
+  "use strict";
+  function jQuery() { }
+
+  __exports__.jQuery = jQuery;// test
+})(window);

--- a/test/features/export_function_bug.js
+++ b/test/features/export_function_bug.js
@@ -1,0 +1,4 @@
+"use strict";
+function jQuery() { };
+exports.jQuery = jQuery;
+// test

--- a/test/features/export_function_bug.yui.js
+++ b/test/features/export_function_bug.yui.js
@@ -1,0 +1,7 @@
+YUI.add("@NAME@", function(Y, NAME, __imports__, __exports__) {
+    "use strict";
+    function jQuery() { }
+
+    __exports__.jQuery = jQuery;// test
+    return __exports__;
+}, "@VERSION@", {"es":true,"requires":[]});


### PR DESCRIPTION
See original discussion [here](https://github.com/ef4/broccoli-es6modules/pull/5)