### PR TITLE
fixes #192 `default` in MemberExpression

### DIFF
--- a/lib/formatters/commonjs_formatter.js
+++ b/lib/formatters/commonjs_formatter.js
@@ -8,6 +8,7 @@ var b = types.builders;
 var util = require('ast-util');
 
 var extend = require('../utils').extend;
+var compatMemberExpression = require('../utils').compatMemberExpression;
 var Replacement = require('../replacement');
 var Formatter = require('./formatter');
 
@@ -76,10 +77,9 @@ CommonJSFormatter.prototype.buildEarlyExports = function(mod) {
 
     assignments.push(b.assignmentExpression(
       '=',
-      b.memberExpression(
+      compatMemberExpression(
         exportObject,
-        b.identifier(name),
-        false
+        name
       ),
       b.identifier(specifier.from)
     ));
@@ -135,10 +135,9 @@ CommonJSFormatter.prototype.buildLateExports = function(mod) {
 
     assignments.push(b.assignmentExpression(
       '=',
-      b.memberExpression(
+      compatMemberExpression(
         exportObject,
-        b.identifier(name),
-        false
+        name
       ),
       from
     ));
@@ -244,7 +243,7 @@ CommonJSFormatter.prototype.defaultExport = function(mod, declaration) {
     // export default function foo () {}
     // -> becomes:
     // function foo () {}
-    // export.default = foo;
+    // export['default'] = foo;
     return [
       declaration,
       b.expressionStatement(b.assignmentExpression(
@@ -408,10 +407,9 @@ CommonJSFormatter.prototype.processExportReassignment = function(mod, nodePath) 
           node,
           b.assignmentExpression(
             '=',
-            b.memberExpression(
+            compatMemberExpression(
               b.identifier('exports'),
-              b.identifier(exportName),
-              false
+              exportName
             ),
             b.identifier(exportName)
           )
@@ -431,10 +429,9 @@ CommonJSFormatter.prototype.processExportReassignment = function(mod, nodePath) 
           ),
           b.assignmentExpression(
             '=',
-            b.memberExpression(
+            compatMemberExpression(
               b.identifier('exports'),
-              b.identifier(exportName),
-              false
+              exportName
             ),
             b.identifier(exportName)
           ),
@@ -463,10 +460,9 @@ CommonJSFormatter.prototype.processExportReassignment = function(mod, nodePath) 
     nodePath,
     b.assignmentExpression(
       '=',
-      b.memberExpression(
+      compatMemberExpression(
         b.identifier('exports'),
-        b.identifier(exportName),
-        false
+        exportName
       ),
       node
     )
@@ -521,7 +517,7 @@ CommonJSFormatter.prototype.processVariableDeclaration = function(mod, nodePath)
  * `identifier` for the given module `mod`. For example:
  *
  *    // rsvp/defer.js, export default
- *    rsvp$defer$$.default
+ *    rsvp$defer$$['default']
  *
  *    // rsvp/utils.js, export function isFunction
  *    rsvp$utils$$.isFunction
@@ -532,10 +528,9 @@ CommonJSFormatter.prototype.processVariableDeclaration = function(mod, nodePath)
  * @private
  */
 CommonJSFormatter.prototype.reference = function(mod, identifier) {
-  return b.memberExpression(
+  return compatMemberExpression(
     b.identifier(mod.id),
-    n.Identifier.check(identifier) ? identifier : b.identifier(identifier),
-    false
+    identifier
   );
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,7 @@
 var recast = require('recast');
 var n = recast.types.namedTypes;
 var b = recast.types.builders;
-var esprima = require('esprima-fb');
+var reserved = require('reserved');
 var realFS = require('fs');
 var Path = require('path');
 
@@ -78,6 +78,33 @@ function IIFE() {
   );
 }
 exports.IIFE = IIFE;
+
+/**
+ * Create a member express that is compatible with ES3. Which means
+ * reserved words will be treated as computed props. E.g.:
+ *
+ *    foo["default"] // instead of `foo.default`
+ *
+ * while still supporting identifiers for non-reserved words:
+ *
+ *    foo.bar        // since bar is not reserved
+ *
+ * @param {Identifier} obj Identifier for the object reference
+ * @param {Identifier|String} prop Identifier or string name for the member property
+ * @return {b.memberExpression} AST for the member expression
+ */
+function compatMemberExpression(obj, prop) {
+  var isIdentifier = n.Identifier.check(prop);
+  var name = isIdentifier ? prop.name : prop;
+  var computed = reserved.indexOf(name) >= 0;
+  return b.memberExpression(
+    obj,
+    computed ? b.literal(name) : (isIdentifier ? prop : b.identifier(prop)),
+    computed
+  );
+}
+
+exports.compatMemberExpression = compatMemberExpression;
 
 /**
  * Create a hierarchy of directories of it does not already exist.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ast-util": "^0.5.1",
     "esprima-fb": "^7001.1.0-dev-harmony-fb",
     "posix-getopt": "^1.0.0",
-    "recast": "^0.9.5"
+    "recast": "^0.9.5",
+    "reserved": "^0.1.2"
   },
   "devDependencies": {
     "browserify": "^6.3.2",


### PR DESCRIPTION
enhances the generation of any MemberExpression, to avoid using literal, non-computed
properties when a reserved word like `default` is used.